### PR TITLE
add image-rendering workaround for firefox esr on debian

### DIFF
--- a/src/styles/routes/index.scss
+++ b/src/styles/routes/index.scss
@@ -251,7 +251,12 @@ h6 {
     image-rendering: pixelated;
     user-select: none;
   }
-
+  @-moz-document url-prefix() {
+    /* Hack to support Firefox 91 (ESR in use on debian) */
+    img{
+      image-rendering: crisp-edges;
+    }
+  }
   > div {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
(badly pixelated icons on homepage)
See also: hackclub/sprig#568